### PR TITLE
fix: get rid of "sw" locale

### DIFF
--- a/edx-platform/locale/config-extra.yaml
+++ b/edx-platform/locale/config-extra.yaml
@@ -11,7 +11,6 @@ locales:
     - hr  # Croatian
     - ro  # Romanian
     - sv  # Swedish
-    - sw  # Swahili
 
 # Copied from edx-platform/conf/locale/config.yaml
 generate_merge:


### PR DESCRIPTION
It is already present as "sw_KE" in edx-platform.